### PR TITLE
Fix index out of range error in condition

### DIFF
--- a/code.go
+++ b/code.go
@@ -193,8 +193,8 @@ func Disassemble(dis *objfile.Disasm, sym *Symbol, opts Options) (*Code, error) 
 
 	// remove trailing interrupts from funcs
 	for len(code.Insts) > 0 &&
-		strings.HasPrefix(code.Insts[len(code.Insts)-1].Text, "INT ") ||
-		code.Insts[len(code.Insts)-1].Text == "?" {
+		(strings.HasPrefix(code.Insts[len(code.Insts)-1].Text, "INT ") ||
+			code.Insts[len(code.Insts)-1].Text == "?") {
 		code.Insts = code.Insts[:len(code.Insts)-1]
 	}
 


### PR DESCRIPTION
A condition code in the code.go causes an index out of range error because of the missing parentheses. The patch will fix it.

```sh
❯ ./lensm -watch lensm 
panic: runtime error: index out of range [-1]

goroutine 10 [running]:
main.Disassemble(0xc0004a4000, 0xc00011c310, {0xc00011c310?})
	/home/tatsumi/Documents/lensm/code.go:197 +0xed2
main.(*ExeUI).loadSymbol(0xc0000a0700, 0xc00011c310)
	/home/tatsumi/Documents/lensm/exe_ui.go:235 +0x65
main.(*ExeUI).Layout(0xc0000a0700, {{{0x578, 0x35c}, {0x578, 0x35c}}, {0x3f800000, 0x3f800000}, {0x8e2d88, 0xc0008d80c8}, {0xc0aca44898ddd597, ...}, ...})
	/home/tatsumi/Documents/lensm/exe_ui.go:157 +0x232
main.(*ExeUI).Run(0xc0000a0700, 0xc0008d8000)
	/home/tatsumi/Documents/lensm/exe_ui.go:122 +0x3e5
main.(*Windows).Open.func1()
	/home/tatsumi/Documents/lensm/windows.go:33 +0x15c
created by main.(*Windows).Open
```