### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module loov.dev/lensm
 
-go 1.21.2
+go 1.21
 
 require (
 	gioui.org v0.3.1


### PR DESCRIPTION
fix errors parsing go.mod: invalid go version

```
go install loov.dev/lensm@main
go: loov.dev/lensm@main (in loov.dev/lensm@v0.0.4): go.mod:3: invalid go version '1.21.2': must match format 1.23
```